### PR TITLE
Remove extra mutrec in AST, add more docs info

### DIFF
--- a/FSharpUnitsOfMeasure/FSharpUnitsOfMeasure.opam
+++ b/FSharpUnitsOfMeasure/FSharpUnitsOfMeasure.opam
@@ -3,8 +3,14 @@ opam-version: "2.0"
 version: "0.1"
 synopsis: "An interpreter for F# with support of units of measure"
 description: "An interpreter for F# with support of units of measure"
-maintainer: ["Daniel Vlasenco" "Andrew Strelnikov"]
-authors: ["Daniel Vlasenco" "Andrew Strelnikov"]
+maintainer: [
+  "Daniel Vlasenco <vlasenko.daniil26@gmail.com>"
+  "Andrew Strelnikov <anbrew200212@gmail.com>"
+]
+authors: [
+  "Daniel Vlasenco <vlasenko.daniil26@gmail.com>"
+  "Andrew Strelnikov <anbrew200212@gmail.com>"
+]
 license: "MIT"
 homepage: "https://github.com/DronShock/FSharpUnitsOfMeasure"
 bug-reports: "https://github.com/DronShock/FSharpUnitsOfMeasure/issues"

--- a/FSharpUnitsOfMeasure/dune-project
+++ b/FSharpUnitsOfMeasure/dune-project
@@ -8,9 +8,15 @@
 
 (license MIT)
 
-(authors "Daniel Vlasenco" "Andrew Strelnikov")
+(authors
+ "Daniel Vlasenco <vlasenko.daniil26@gmail.com>"
+ "Andrew Strelnikov <anbrew200212@gmail.com>"
+ )
 
-(maintainers "Daniel Vlasenco" "Andrew Strelnikov")
+(maintainers
+ "Daniel Vlasenco <vlasenko.daniil26@gmail.com>"
+ "Andrew Strelnikov <anbrew200212@gmail.com>"
+ )
 
 (bug_reports "https://github.com/DronShock/FSharpUnitsOfMeasure/issues")
 
@@ -31,6 +37,4 @@
   bisect_ppx
   (odoc :with-doc)
   (ocamlformat :build)
-  ; base
-  ; After adding dependencies to 'dune' files and the same dependecies here too
   ))

--- a/FSharpUnitsOfMeasure/lib/ast/ast.ml
+++ b/FSharpUnitsOfMeasure/lib/ast/ast.ml
@@ -39,15 +39,14 @@ type pattern =
   (** Constant patterns: [1], ['a'], ["foo"], [3.14], [5.0<cm>] *)
   | Pattern_tuple of pattern list
   (** Tuple patterns: [(P1; ..., Pn)]
-
       Invariant: [n >= 2]
     *)
   | Pattern_or of pattern * pattern (** Or patterns: [P1 | P2] *)
 [@@deriving show { with_path = false }]
 
 type rec_flag =
-  | Nonrecursive
-  | Recursive
+  | Nonrecursive (** For nonrecursive function declarations *)
+  | Recursive (** For recursive function declarations *)
 [@@deriving show { with_path = false }]
 
 type val_binding = Binding of pattern * expression
@@ -61,21 +60,25 @@ and expression =
   (** Identificator name expressions: [x] *)
   | Expr_tuple of expression list
   (** Tuple expressions: [(E1, ..., En)]
-
       Invariant: [n >= 2]
     *)
   | Expr_fun of pattern * expression
-  (** Anonimous functions: [Exp_fun(P, E)] represents [fun P -> E] *)
+  (** Anonimous functions: [Exp_fun(P, E)] represents [fun P -> E]
+      Invariant: [n >= 1]
+    *)
   | Expr_let of rec_flag * val_binding list * expression option
   (** [Expr_let(rec_flag, [(P1, E1); ...; (Pn, En)], E)] represents:
         - [let P1 = E1 and ... and Pn = En in E] when rec_flag is Nonrecursive
         - [let rec P1 = E1 and ... and Pn = En in E] when rec_flag is Recursive
+      Invariant: [n >= 1]
     *)
   | Expr_ifthenelse of expression * expression * expression option
   (** [if E1 then E2 else E3] *)
   | Expr_apply of expression * expression (** Application [E1 E2] *)
   | Expr_match of expression * (pattern * expression) list
-  (** [match E with P1 -> E1 | ... | Pn -> En] *)
+  (** [match E with P1 -> E1 | ... | Pn -> En]
+      Invariant: [n >= 1]
+    *)
 [@@deriving show { with_path = false }]
 
 type structure_item =
@@ -85,6 +88,7 @@ type structure_item =
   (** [Str_value(rec_flag, [(P1, E1); ...; (Pn, En)])] represents:
       - [let P1 = E1 and ... and Pn = En] when rec_flag is Nonrecursive
       - [let rec P1 = E1 and ... and Pn = En] when rec_flag is Recursive
+      Invariant: [n >= 1]
     *)
 [@@deriving show { with_path = false }]
 

--- a/FSharpUnitsOfMeasure/lib/ast/ast.ml
+++ b/FSharpUnitsOfMeasure/lib/ast/ast.ml
@@ -18,8 +18,8 @@ type measure =
 [@@deriving show { with_path = false }]
 
 type measure_val =
-  | Mval_int of int
-  | Mval_float of float
+  | Mval_int of int (** Integer numbers with units of measure *)
+  | Mval_float of float (** Real numbers with units of measure *)
 [@@deriving show { with_path = false }]
 
 type constant =

--- a/FSharpUnitsOfMeasure/lib/ast/ast.ml
+++ b/FSharpUnitsOfMeasure/lib/ast/ast.ml
@@ -2,6 +2,26 @@
 
 (** SPDX-License-Identifier: MIT *)
 
+type rational_exp =
+  | Integer of int (** Integer exponent: [2] *)
+  | Rational of int * int (** Rational exponent: [3/2] *)
+  | Negate of rational_exp (** Negation of exponent: [-1], [-(1/2)] *)
+  | Paren of rational_exp (** Parentheses around exponent: [(5)], [(-2/3)] *)
+[@@deriving show { with_path = false }]
+
+type measure =
+  | Measure_ident of string (** Measure identificator: [<m>] *)
+  | Measure_prod of measure * measure (** Measure product: [<sec * h>], [<kg m>] *)
+  | Measure_div of measure * measure (** Measure division: [<m / sec>] *)
+  | Measure_pow of measure * rational_exp
+  (** Measure to the rational power: [<cm^3>] *)
+[@@deriving show { with_path = false }]
+
+type measure_val =
+  | Mval_int of int
+  | Mval_float of float
+[@@deriving show { with_path = false }]
+
 type constant =
   | Const_bool of bool (** Boolean constants [true] and [false] *)
   | Const_int of int (** Integer constants: [1] *)
@@ -10,26 +30,6 @@ type constant =
   | Const_float of float (** Float constants: [3.14], [1e+5], [5.9E-3] *)
   | Const_measure of measure_val * measure
   (** Measure constants: [5.0<cm>], [3<kg>] *)
-[@@deriving show { with_path = false }]
-
-and measure_val =
-  | Mval_int of int
-  | Mval_float of float
-[@@deriving show { with_path = false }]
-
-and measure =
-  | Measure_ident of string (** Measure identificator: [<m>] *)
-  | Measure_prod of measure * measure (** Measure product: [<sec * h>], [<kg m>] *)
-  | Measure_div of measure * measure (** Measure division: [<m / sec>] *)
-  | Measure_pow of measure * rational_exp
-  (** Measure to the rational power: [<cm^3>] *)
-[@@deriving show { with_path = false }]
-
-and rational_exp =
-  | Integer of int (** Integer exponent: [2] *)
-  | Rational of int * int (** Rational exponent: [3/2] *)
-  | Negate of rational_exp (** Negation of exponent: [-1], [-(1/2)] *)
-  | Paren of rational_exp (** Parentheses around exponent: [(5)], [(-2/3)] *)
 [@@deriving show { with_path = false }]
 
 type pattern =


### PR DESCRIPTION
- Mutual recursion was not needed in some types of AST, so I removed it.
- Added more ocamldocs to AST, more invariants were presented.
- Added emails to dune-project and regenerate .opam file.